### PR TITLE
Rails: Support setting attributes which are mass-assignment restricted wi

### DIFF
--- a/lib/object_daddy.rb
+++ b/lib/object_daddy.rb
@@ -33,7 +33,10 @@ module ObjectDaddy
           : const_get(@concrete_subclass_name).spawn(args)
       end
       generate_values(args)
-      instance = new(args)
+      instance = new
+      args.each_pair do |attribute, value|
+        instance.send("#{attribute}=", value)  # support setting of mass-assignment protected attributes
+      end
       yield instance if block_given?
       instance
     end

--- a/spec/object_daddy_spec.rb
+++ b/spec/object_daddy_spec.rb
@@ -606,6 +606,10 @@ if File.exists?("#{File.dirname(__FILE__)}/../../../../config/environment.rb")
   class YaModel < ActiveRecord::Base
   end
 
+  class ProtectedAttribute < ActiveRecord::Base
+    attr_accessible :public_name
+  end
+
   describe ObjectDaddy, "when integrated with Rails" do
     it "should provide a means of generating and saving a class instance" do
       Frobnitz.should respond_to(:generate)
@@ -856,6 +860,20 @@ if File.exists?("#{File.dirname(__FILE__)}/../../../../config/environment.rb")
     it 'should allow attributes to be overriden with string keys' do
       Frobnitz.generator_for :name => 'thing'
       Frobnitz.generate('name' => 'boo').name.should == 'boo'
+    end
+
+    describe "supporting mass-assignment protected attributes" do
+      it "should allow setting a value for a non-protected attribute" do
+        ProtectedAttribute.generate!(:public_name => 'no_worries').public_name.should == 'no_worries'
+      end
+
+      it "should have a protected attribute, which is not set when using regular create!" do
+        ProtectedAttribute.create!(:private_name => 'protected name').private_name.should == nil
+      end
+
+      it "should allow setting a value for a protected attribute" do
+        ProtectedAttribute.generate!(:private_name => 'protected name').private_name.should == 'protected name'
+      end
     end
   end
 end

--- a/spec/resources/schema
+++ b/spec/resources/schema
@@ -27,4 +27,9 @@ ActiveRecord::Schema.define(:version => 0) do
   create_table :ya_models, :force => true do |t|
     t.column :name, :string
   end
+
+  create_table :protected_attributes, :force => true do |t|
+    t.column :public_name, :string
+    t.column :private_name, :string
+  end
 end


### PR DESCRIPTION
Rails: Support setting attributes which are mass-assignment restricted with attr_accessible / attr_protected

Calling all individual setter-methods instead of bulk-assigning using a hash.
